### PR TITLE
Skip unsupported ObjC methods

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -252,7 +252,11 @@ function listClassesJson(args) {
       throw new Error('Class not found');
     return klass.$ownMethods
     .reduce((result, methodName) => {
-      result[methodName] = klass[methodName].implementation;
+      try {
+        result[methodName] = klass[methodName].implementation;
+      } catch(_) {
+        console.log('warning: unsupported method \'' + methodName + '\'');
+      }
       return result;
     }, {});
   }


### PR DESCRIPTION
This is to avoid this problem:

```
[0x181dff1ac]> =!ic NSString
Expected token '=' not found
```

Which happens because a couple of methods seems to be not yet supported by frida and trying to retrieve them result in a failure:

```
[0x181dff1ac]> =! ObjC.classes.NSString['- cl_json_serializeValue:']
throw new Error("Expected token '=' not found")
```

While all other methods work:

```
[0x181dff1ac]> =! ObjC.classes.NSString['- initWithFormat:']
{handle:{},selector:{},implementation:{},returnType:"pointer",argumentTypes:["pointer","pointer","pointer"],types:"@24@0:8@16"}
```

So, catching the exception there make it possible to work with all other methods, while a warning is displayed to the user:

```
[0x00000000]> =!ic* NSString
warning: unsupported method '- cl_json_serializeValue:'
warning: unsupported method '- cl_json_serializeValue:'
f sym.objc.NSString._attendeeNameExtensions = 0x000000018c69f938
f sym.objc.NSString._attendeePartialSurnames = 0x000000018c69fa9c
f sym.objc.NSString.safari_stringWithJSValuecontext:nullStringPolicy: = 0x000000018cb217d0
f sym.objc.NSString._safari_reverseEnumerateComponentsusingBlock: = 0x000000018cb21d00
f sym.objc.NSString.safari_stringAsHexWithBufferlength: = 0x000000018cb24618
f sym.objc.NSString.safari_stringWithJSValuecontext: = 0x000000018cb2188c
f sym.objc.NSString.safari_stringWithUTF8Byteslength: = 0x000000018cb238c8
f sym.objc.NSString.safari_stringByBase64EncodingData = 0x000000018cb2450c
f sym.objc.NSString.safari_stringAsHexWithData = 0x000000018cb24580
[...]
```