### PR TITLE
Dump full env if no key

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -889,12 +889,11 @@ function getOrSetEnvJson(args) {
 
 function getEnv() {
   const result = [];
-  for (
-    let envp = __environ;
-    !envp.isNull() && !Memory.readPointer(envp).isNull();
-    envp = envp.add(Process.pointerSize)
-  ) {
-    result.push(Memory.readCString(Memory.readPointer(envp)));
+  let envp = __environ;
+  let env;
+  while (!envp.isNull() && !(env = Memory.readPointer(envp)).isNull()) {
+    result.push(Memory.readCString(env));
+    envp = envp.add(Process.pointerSize);
   }
   return result;
 }

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -909,7 +909,6 @@ function getEnvJson() {
   });
 }
 
-
 function dlopen(args) {
   const path = args[0];
   const handle = _dlopen(Memory.allocUtf8String(path), RTLD_GLOBAL | RTLD_LAZY);


### PR DESCRIPTION

```
[0x00000000]> \envj
[{"key":"TMPDIR","value":"/private/var/mobile/Containers/Data/Application/8D32A9E7-61C4-4A52-BB20-F8E5CF83793E/tmp"},{"key":"__CF_USER_TEXT_ENCODING","value":"0x1F5:0:0"},{"key":"HOME","value":"/private/var/mobile/Containers/Data/Application/8D32A9E7-61C4-4A52-BB20-F8E5CF83793E"},{"key":"SHELL","value":"/bin/sh"},{"key":"CFFIXED_USER_HOME","value":"/private/var/mobile/Containers/Data/Application/8D32A9E7-61C4-4A52-BB20-F8E5CF83793E"},{"key":"FBSClientLogging","value":"0"},{"key":"PATH","value":"/usr/bin:/bin:/usr/sbin:/sbin"},{"key":"LOGNAME","value":"mobile"},{"key":"XPC_SERVICE_NAME","value":"UIKitApplication:com.nowsecure.demo.rvia[0x962f]"},{"key":"CLASSIC","value":"0"},{"key":"USER","value":"mobile"},{"key":"XPC_FLAGS","value":"0x0"},{"key":"foo","value":"blahs"}]
[0x00000000]> \env
TMPDIR=/private/var/mobile/Containers/Data/Application/8D32A9E7-61C4-4A52-BB20-F8E5CF83793E/tmp
__CF_USER_TEXT_ENCODING=0x1F5:0:0
HOME=/private/var/mobile/Containers/Data/Application/8D32A9E7-61C4-4A52-BB20-F8E5CF83793E
SHELL=/bin/sh
CFFIXED_USER_HOME=/private/var/mobile/Containers/Data/Application/8D32A9E7-61C4-4A52-BB20-F8E5CF83793E
FBSClientLogging=0
PATH=/usr/bin:/bin:/usr/sbin:/sbin
LOGNAME=mobile
XPC_SERVICE_NAME=UIKitApplication:com.nowsecure.demo.rvia[0x962f]
CLASSIC=0
USER=mobile
XPC_FLAGS=0x0
foo=blahs
[0x00000000]> \env foo=blah
foo=blah
[0x00000000]> \env
TMPDIR=/private/var/mobile/Containers/Data/Application/8D32A9E7-61C4-4A52-BB20-F8E5CF83793E/tmp
__CF_USER_TEXT_ENCODING=0x1F5:0:0
HOME=/private/var/mobile/Containers/Data/Application/8D32A9E7-61C4-4A52-BB20-F8E5CF83793E
SHELL=/bin/sh
CFFIXED_USER_HOME=/private/var/mobile/Containers/Data/Application/8D32A9E7-61C4-4A52-BB20-F8E5CF83793E
FBSClientLogging=0
PATH=/usr/bin:/bin:/usr/sbin:/sbin
LOGNAME=mobile
XPC_SERVICE_NAME=UIKitApplication:com.nowsecure.demo.rvia[0x962f]
CLASSIC=0
USER=mobile
XPC_FLAGS=0x0
foo=blah

```