### PR TITLE
Fix instruction-level breakpoints

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -481,15 +481,13 @@ function breakpoint (args) {
       stopped: false,
       address: addrString,
       continue: false,
-      handler: Interceptor.attach(addr, {
-        onEnter: function (args) {
-          breakpoints[addrString].stopped = true;
-          while (breakpointExist(addr)) {
-            Thread.sleep(1);
-          }
-          breakpoints[addrString].stopped = false;
-          breakpoints[addrString].continue = false;
+      handler: Interceptor.attach(addr, function (args) {
+        breakpoints[addrString].stopped = true;
+        while (breakpointExist(addr)) {
+          Thread.sleep(1);
         }
+        breakpoints[addrString].stopped = false;
+        breakpoints[addrString].continue = false;
       })
     };
     breakpoints[addrString] = bp;


### PR DESCRIPTION
The user may decide to put a breakpoint in the middle of a function,
which means we need to tell Interceptor that we want an instruction-
level probe. Otherwise the return address will get corrupted due to
Interceptor assuming we're giving it the address of a function, so it
can trap the return.