### PR TITLE
Mismatch versions error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include config.mk
 
-radare2_version = 1.5.0
-frida_version = 10.0.10
+radare2_version = 1.6.0
+frida_version = 10.0.15
 
 ifeq ($(shell uname -o 2> /dev/null),Android)
 frida_os := android


### PR DESCRIPTION
Mismatch versions error while installing r2frida from r2pm

~~~~bash
jbono@MacBook [~/radare2]> r2 frida://1234
Module version mismatch /Users/jbono/.config/radare2/plugins/io_frida.dylib (1.5.0-git) vs (1.6.0-git)
Cannot open 'frida://1234'
~~~~

Workaround:

~~~~bash
jbono@MacBook [~/radare2]> pip uninstall frida
jbono@MacBook [~/radare2]> pip install frida==10.0.10
~~~~

Now it works.

Credits: @as0ler