### PR TITLE
Fix ia32 / x86 arch name conversion

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -421,6 +421,7 @@ function dumpInfoR2 () {
 
 function getR2Arch (arch) {
   switch (arch) {
+    case 'ia32':
     case 'x64':
       return 'x86';
     case 'arm64':


### PR DESCRIPTION
This makes `.\i*` command work for x86 32bit apps too.