### PR TITLE
Various fixes

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -116,7 +116,7 @@ const pendingCmdSends = [];
 let sendingCommand = false;
 
 function nameFromAddress (address) {
-  const at = DebugSymbol.fromAddress(ptr(address)).name
+  const at = DebugSymbol.fromAddress(ptr(address)).name;
   if (at === null) {
     const module = Process.findModuleByAddress(address);
     if (module === null) {
@@ -256,8 +256,7 @@ function dxHexpairs (args) {
 
 function evalCode (args) {
   const code = args.join(' ');
-  eval(code); // eslint-disable-line
-  return '';
+  return eval(code); // eslint-disable-line
 }
 
 function printHexdump (lenstr) {
@@ -759,7 +758,7 @@ function lookupSymbolJson (args) {
 
 function listImports (args) {
   return listImportsJson(args)
-  .map(({type, name, module, address}) => [address, type[0], name, module].join(' '))
+  .map(({type, name, module, address}) => [address, type ? type[0] : ' ', name, module].join(' '))
   .join('\n');
 }
 
@@ -1038,7 +1037,7 @@ function dumpRegisters () {
 
       const heading = `tid ${id} ${state}`;
 
-      const names = Object.keys(context);
+      const names = Object.keys(JSON.parse(JSON.stringify(context)));
       names.sort(compareRegisterNames);
       const values = names
       .map((name, index) => alignRight(name, 3) + ' : ' + padPointer(context[name]))
@@ -1197,7 +1196,7 @@ function traceFormat (args) {
   }
   const traceOnEnter = format.indexOf('^') !== -1;
   const traceBacktrace = format.indexOf('+') !== -1;
-  const at = nameFromAddress (address);
+  const at = nameFromAddress(address);
 
   const listener = Interceptor.attach(ptr(address), {
     myArgs: [],
@@ -1245,6 +1244,7 @@ function traceRegs (args) {
           tail = ' (' + tail + ')';
         }
       } catch (e) {
+        tail = '';
       }
       return r + ' = ' + this.context[r] + tail;
     }).join('\n\t'));

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -256,7 +256,8 @@ function dxHexpairs (args) {
 
 function evalCode (args) {
   const code = args.join(' ');
-  return eval(code); // eslint-disable-line
+  const result = eval(code); // eslint-disable-line
+  return (result !== undefined) ? result : '';
 }
 
 function printHexdump (lenstr) {
@@ -1297,6 +1298,7 @@ function trace (args) {
 
 function clearTrace (args) {
   traceListeners.splice(0).forEach(lo => lo.listener.detach());
+  return '';
 }
 
 function interceptHelp (args) {


### PR DESCRIPTION
- avoid js error when `type` is undefined in `ii`
- get register names in `dr`, because Object.keys doesn’t work on `context` as is
- assign an empty string to `tail` in case of exception to avoid js errors
- return `eval()` result
- semistandard happy again