### PR TITLE
Fixed the interceptRet function

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -2485,10 +2485,10 @@ function interceptRet(target, value) {
   if (target.startsWith('java:')) {
     return interceptRetJavaExpression(target, value);
   }
-  const p = ptr(args[0]);
+  const p = ptr(target);
   Interceptor.attach(p, {
     onLeave (retval) {
-      retval.replace(ptr('0'));
+      retval.replace(ptr(value));
     }
   });
 }


### PR DESCRIPTION
The interceptRet, which is used by the di method, used the args instead of the target parameter, and had hardcoded the 0 value instead using the value parameter.