### PR TITLE
Add symbols.unredact config variable

### DIFF
--- a/src/agent/config.js
+++ b/src/agent/config.js
@@ -27,9 +27,9 @@ const configValidator = {
   'stalker.event': configValidateStalkerEvent,
   'stalker.timeout': configValidateStalkerTimeout,
   'stalker.in': configValidateStalkerIn,
-  'hook.backtrace': configValidateHookBacktrace,
-  'hook.verbose': configValidateHookVerbose,
-  'symbols.unredact': configValidateSymbolsUnredact
+  'hook.backtrace': configValidateBoolean,
+  'hook.verbose': configValidateBoolean,
+  'symbols.unredact': configValidateBoolean
 };
 
 function configHelpSearchIn () {
@@ -123,36 +123,28 @@ function configHelpSymbolsUnredact () {
   `;
 }
 
-function configValidateHookVerbose (val) {
-  if (typeof (val) === 'boolean') {
-    return true;
-  }
-  return ['true', 'false'].indexOf(val) !== -1;
-}
-
-function configValidateHookBacktrace (val) {
-  return ['true', 'false'].indexOf(val) !== -1;
-}
-
 function configValidateStalkerIn (val) {
   return ['raw', 'app', 'modules'].indexOf(val) !== -1;
 }
 
-function configValidateSymbolsUnredact (val) {
-  if (typeof (val) === 'boolean') {
-    return true;
-  }
-  return ['true', 'false'].indexOf(val) !== -1;
+function configValidateBoolean (val) {
+  return isTrue(val) || isFalse(val);
 }
 
 function isTrue (x) {
-  return (x === true || x === 1 || x === 'true');
+  return (x === true || x === 1 || x === '1' || (/(true)/i).test(x));
 }
+
+function isFalse (x) {
+  return (x === false || x === 0 || x === '0' || (/(false)/i).test(x));
+}
+
 function asR2Script () {
   return Object.keys(config)
     .map(k => 'e ' + k + '=' + config[k])
     .join('\n');
 }
+
 function set (k, v) {
   if (configValidator[k] !== undefined) {
     if (!configValidator[k](v)) {

--- a/src/agent/config.js
+++ b/src/agent/config.js
@@ -9,7 +9,7 @@ const config = {
   'stalker.in': 'raw',
   'hook.backtrace': true,
   'hook.verbose': true,
-  'symbols.unredact': true
+  'symbols.unredact': Process.platform === 'darwin'
 };
 
 const configHelp = {

--- a/src/agent/config.js
+++ b/src/agent/config.js
@@ -8,7 +8,8 @@ const config = {
   'stalker.timeout': 5 * 60,
   'stalker.in': 'raw',
   'hook.backtrace': true,
-  'hook.verbose': true
+  'hook.verbose': true,
+  'symbols.unredact': true
 };
 
 const configHelp = {
@@ -17,7 +18,8 @@ const configHelp = {
   'stalker.timeout': configHelpStalkerTimeout,
   'stalker.in': configHelpStalkerIn,
   'hook.backtrace': configHelpHookBacktrace,
-  'hook.verbose': configHelpHookVerbose
+  'hook.verbose': configHelpHookVerbose,
+  'symbols.unredact': configHelpSymbolsUnredact
 };
 
 const configValidator = {
@@ -26,7 +28,8 @@ const configValidator = {
   'stalker.timeout': configValidateStalkerTimeout,
   'stalker.in': configValidateStalkerIn,
   'hook.backtrace': configValidateHookBacktrace,
-  'hook.verbose': configValidateHookVerbose
+  'hook.verbose': configValidateHookVerbose,
+  'symbols.unredact': configValidateSymbolsUnredact
 };
 
 function configHelpSearchIn () {
@@ -112,6 +115,14 @@ function configHelpStalkerIn () {
   `;
 }
 
+function configHelpSymbolsUnredact () {
+  return `Try to get symbol names from debug symbols when they're "redacted":
+
+    true            try to unredact (the default)
+    false           do not attempt to unredact
+  `;
+}
+
 function configValidateHookVerbose (val) {
   if (typeof (val) === 'boolean') {
     return true;
@@ -125,6 +136,13 @@ function configValidateHookBacktrace (val) {
 
 function configValidateStalkerIn (val) {
   return ['raw', 'app', 'modules'].indexOf(val) !== -1;
+}
+
+function configValidateSymbolsUnredact (val) {
+  if (typeof (val) === 'boolean') {
+    return true;
+  }
+  return ['true', 'false'].indexOf(val) !== -1;
 }
 
 function isTrue (x) {

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -34,7 +34,7 @@ const allocPool = {};
 const pendingCmds = {};
 const pendingCmdSends = [];
 let sendingCommand = false;
-const insaneSet = new Set(['`', '$', '{', '}', '~', '|', ';', '#', '@', '&', '<', '>', ' ', '(', ')']);
+const specialChars = '`${}~|;#@&<> ()';
 
 function numEval (expr) {
   return new Promise((resolve, reject) => {
@@ -845,17 +845,7 @@ function listSymbolsR2 (args) {
 }
 
 function sanitizeString (str) {
-  const result = [];
-
-  for (const c of str) {
-    if (insaneSet.has(c)) {
-      result.push('_');
-    } else {
-      result.push(c);
-    }
-  }
-
-  return result.join('');
+  return str.split('').map(c => specialChars.indexOf(c) === -1 ? c : '_').join('');
 }
 
 function listSymbolsJson (args) {

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -34,6 +34,7 @@ const allocPool = {};
 const pendingCmds = {};
 const pendingCmdSends = [];
 let sendingCommand = false;
+const insaneSet = new Set(['`', '$', '{', '}', '~', '|', ';', '#', '@', '&', '<', '>', ' ', '(', ')']);
 
 function numEval (expr) {
   return new Promise((resolve, reject) => {
@@ -836,17 +837,41 @@ function listSymbols (args) {
 
 function listSymbolsR2 (args) {
   return listSymbolsJson(args)
+    .filter(({ address }) => !address.isNull())
     .map(({ type, name, address }) => {
-      return ['f', 'sym.' + type.substring(0, 3) + '.' + name, '=', address].join(' ');
+      return ['f', 'sym.' + type.substring(0, 3) + '.' + sanitizeString(name), '=', address].join(' ');
     })
     .join('\n');
+}
+
+function sanitizeString (str) {
+  const result = [];
+
+  for (const c of str) {
+    if (insaneSet.has(c)) {
+      result.push('_');
+    } else {
+      result.push(c);
+    }
+  }
+
+  return result.join('');
 }
 
 function listSymbolsJson (args) {
   const currentModule = (args.length > 0)
     ? Process.getModuleByName(args[0])
     : Process.getModuleByAddress(offset);
-  return Module.enumerateSymbols(currentModule.name);
+  const symbols = Module.enumerateSymbols(currentModule.name);
+  return symbols.map(sym => {
+    if (config.getBoolean('symbols.unredact') && sym.name.indexOf('redacted') !== -1) {
+      const dbgSym = DebugSymbol.fromAddress(sym.address);
+      if (dbgSym !== null) {
+        sym.name = dbgSym.name;
+      }
+    }
+    return sym;
+  });
 }
 
 function lookupDebugInfo (args) {


### PR DESCRIPTION
`true` by default, it allows to retrieve the symbol name from the debug symbols (CoreSymbolication) when it’s “redacted” in apple’s dyld cache.

Also, while at it, added some sanitisation on flag names, to avoid accidental creation of garbage files and such.

Example:
```
[0x00000000]> \e symbols.unredact=?
Try to get symbol names from debug symbols when they're "redacted":

    true            try to unredact (the default)
    false           do not attempt to unredact

[0x00000000]> \is* CoreText~redact
[0x00000000]> \e symbols.unredact=false

[0x00000000]> \is* CoreText~redact
Do you want to print 4379 lines? (y/N)
```