### PR TITLE
dlopen cmd changed to new Frida API Module.load()

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -503,7 +503,6 @@ const _getenv = sym('getenv', 'pointer', ['pointer']);
 const _setenv = sym('setenv', 'int', ['pointer', 'pointer', 'int']);
 const _getpid = sym('getpid', 'int', []);
 const _getuid = sym('getuid', 'int', []);
-const _dlopen = sym('dlopen', 'pointer', ['pointer', 'int']);
 const _dup2 = sym('dup2', 'int', ['int', 'int']);
 const _readlink = sym('readlink', 'int', ['pointer', 'pointer', 'int']);
 const _fstat = Module.findExportByName(null, 'fstat')
@@ -1872,11 +1871,7 @@ function getEnvJson () {
 
 function dlopen (args) {
   const path = args[0];
-  const handle = _dlopen(Memory.allocUtf8String(path), RTLD_GLOBAL | RTLD_LAZY);
-  if (handle.isNull()) {
-    throw new Error('Failed to load: ' + path);
-  }
-  return handle.toString();
+  return Module.load(path);
 }
 
 function formatArgs (args, fmt) {


### PR DESCRIPTION
Solve https://github.com/nowsecure/r2frida/issues/139. But we need to create a `chcon` command in r2frida to fix the issue of loading modules from arbitrary paths (e.g. `/data/local/tmp/`)

- Android:
```
jasmine_sprout:/data/local/tmp # ls -lah libnative-lib64.so
-rwxrwxrwx 1 shell shell 10K 2019-06-07 20:05 libnative-lib64.so
jasmine_sprout:/data/local/tmp # file libnative-lib64.so
libnative-lib64.so: ELF shared object, 64-bit LSB arm64, BuildID=d6b504a970801a9d9412157f0efe860ba39c199d, for Android 24, built by NDK r19c (5345600), stripped
jasmine_sprout:/data/local/tmp # chcon u:object_r:frida_file:s0 /data/local/tmp/libnative-lib64.so
```

- r2frida now without adding path with `chcon`:
```
[0x00000000]> \ console.log(Process.pointerSize)
8
[0x00000000]> \dl /data/local/tmp/libnative-lib64.so
dlopen failed: couldn't map "/data/local/tmp/libnative-lib64.so" segment 0: Permission denied
```

- r2frida now after adding path with `chcon`:
```
[0x00000000]> \dl /data/local/tmp/libnative-lib64.so
{"name":"libnative-lib64.so","base":"0x7006e46000","size":77824,"path":"/data/local/tmp/libnative-lib64.so"}
[0x00000000]> \iE libnative-lib64.so
0x7006e46d8c f Java_re_enovella_MainActivity_init
```

Thanks to @oleavr who gave the idea.