### PR TITLE
Implement native enumeration of devices and processes

### DIFF
--- a/src/io_frida.c
+++ b/src/io_frida.c
@@ -789,7 +789,7 @@ static bool parse_device_id_as_uriroot(char *path, const char *arg, R2FridaLaunc
 			} else {
 				dumpDevices ();
 			}
-			free (rest);
+			g_free (rest);
 		}
 		return true;
 	}
@@ -866,7 +866,7 @@ static bool parse_target(const char *pathname, R2FridaLaunchOptions *lo) {
 	char *first_word = g_strndup (first_field, second_field - first_field - 1);
 
 	if (parse_device_id_as_uriroot (first_word, second_field, lo)) {
-		free (first_word);
+		g_free (first_word);
 		return true;
 	}
 	lo->device_id = first_word;


### PR DESCRIPTION
To avoid depending on [frida-tools](https://github.com/frida/frida-tools).

Also fix two potential heap corruptions: string allocations made by GLib
should be freed using `g_free()`, not `free()`.