### PR TITLE
dispatch arch info at agent load

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -269,6 +269,9 @@ async function initBasicInfoFromTarget (args) {
 e dbg.backend =io
 e anal.autoname=true
 e cmd.fcn.new=aan
+e asm.arch=` + getR2Arch(Process.arch) + `
+e asm.bits=` + (pointerSize * 8) + `
+e asm.os=` + Process.platform + `
 .=!i*
 .=!ie*
 .=!il*


### PR DESCRIPTION
needed for disasm and lot of different things without the needed of .\i* each timeu