### PR TITLE
Re-introduce the check for fs.io commands

### DIFF
--- a/src/io_frida.c
+++ b/src/io_frida.c
@@ -739,8 +739,12 @@ static char *__system(RIO *io, RIODesc *fd, const char *command) {
 	value = json_object_get_string_member (result, "value");
 	char *sys_result = NULL;
 	if (value && strcmp (value, "undefined")) {
-		sys_result = strdup (value);
-		io->cb_printf ("%s", value);
+		bool is_fs_io = command[0] == 'm';
+		if (is_fs_io) {
+			sys_result = strdup (value);
+		} else {
+			io->cb_printf ("%s\n", value);
+		}
 	}
 	json_object_unref (result);
 


### PR DESCRIPTION
To avoid duplicated output with “cat” or “mc”. The idea is that “\mc” shouldn’t be used directly but only through “mc”.