### PR TITLE
export hostCmdj function to agent

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -4075,6 +4075,7 @@ function hostCmd (cmd) {
 }
 
 global.r2frida.hostCmd = hostCmd;
+global.r2frida.hostCmdj = hostCmdj;
 global.r2frida.logs = logs;
 global.r2frida.log = traceLog;
 global.r2frida.safeio = false;


### PR DESCRIPTION
Simple change, simply exports `hostCmdj`, no internal changes to the working of the function.
Wraps `hostCmd` already, so doesn't need further changes.