### PR TITLE
Bump Frida to 12.11.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include config.mk
 
 r2_version=$(VERSION)
-frida_version=12.11.11
+frida_version=12.11.12
 
 ifeq ($(strip $(frida_os)),)
 ifeq ($(shell uname -o 2> /dev/null),Android)


### PR DESCRIPTION
For initialisation of CoreFoundation on i/macOS

Fixes https://github.com/nowsecure/r2frida/issues/232