### PR TITLE
Feature/trace summary #252

### DIFF
--- a/src/agent/config.js
+++ b/src/agent/config.js
@@ -11,6 +11,7 @@ const config = {
   'hook.backtrace': true,
   'hook.verbose': true,
   'hook.logs': true,
+  'hook.output': 'simple',
   'file.log': '',
   'symbols.unredact': Process.platform === 'darwin'
 };
@@ -24,6 +25,7 @@ const configHelp = {
   'hook.backtrace': configHelpHookBacktrace,
   'hook.verbose': configHelpHookVerbose,
   'hook.logs': configHelpHookLogs,
+  'hook.output': configHelpHookOutput,
   'file.log': configHelpFileLog,
   'symbols.unredact': configHelpSymbolsUnredact
 };
@@ -37,6 +39,7 @@ const configValidator = {
   'hook.backtrace': configValidateBoolean,
   'hook.verbose': configValidateBoolean,
   'hook.logs': configValidateBoolean,
+  'hook.output': configValidateString,
   'file.log': configValidateString,
   'symbols.unredact': configValidateBoolean
 };
@@ -123,6 +126,13 @@ function configHelpHookLogs () {
   return `Save hook trace logs internally in the agent. Use \\dtl to list them
 
     true | false    to enable or disable the option (enabled by default)
+  `;
+}
+
+function configHelpHookOutput () {
+  return `Choose output format.
+
+    simple | json   (simple by default)
   `;
 }
 

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -2546,7 +2546,7 @@ function traceFormat (args) {
         if (config.getBoolean('hook.backtrace')) {
           traceMessage.backtrace = Thread.backtrace(this.context).map(DebugSymbol.fromAddress);
         }
-        if (config.getString('hook.output').toLowerCase() === 'json') {
+        if (config.getString('hook.output') === 'json') {
           traceEmit(traceMessage);
         } else {
           let msg = `[dtf onEnter][${traceMessage.timestamp}] ${name}@${address} - args: ${this.myArgs.join(', ')}`;
@@ -2571,7 +2571,7 @@ function traceFormat (args) {
         if (config.getBoolean('hook.backtrace')) {
           traceMessage.backtrace = Thread.backtrace(this.context).map(DebugSymbol.fromAddress);
         }
-        if (config.getString('hook.output').toLowerCase() === 'json') {
+        if (config.getString('hook.output') === 'json') {
           traceEmit(traceMessage);
         } else {
           let msg = `[dtf onLeave][${traceMessage.timestamp}] ${name}@${address} - args: ${this.myArgs.join(', ')}. Retval: ${retval.toString()}`;
@@ -2758,7 +2758,7 @@ function traceRegs (args) {
     if (config.getBoolean('hook.backtrace')) {
       traceMessage.backtrace = Thread.backtrace(this.context).map(DebugSymbol.fromAddress);
     }
-    if (config.getString('hook.output').toLowerCase() === 'json') {
+    if (config.getString('hook.output') === 'json') {
       traceEmit(traceMessage);
     } else {
       let msg = `[dtr][${traceMessage.timestamp}] ${address} - registers: ${JSON.stringify(regState)}`;
@@ -2850,7 +2850,7 @@ function traceJava (klass, method) {
         result: res,
         values: args
       };
-      if (config.getString('hook.output').toLowerCase() === 'json') {
+      if (config.getString('hook.output') === 'json') {
         traceEmit(traceMessage);
       } else {
         let msg = `[java trace][${traceMessage.timestamp}] ${klass}:${method} - args: ${JSON.stringify(args)}. Return value: ${res.toString()}`;
@@ -3009,7 +3009,7 @@ function traceReal (name, addressString) {
       values: values,
     };
     traceListener.hits++;
-    if (config.getString('hook.output').toLowerCase() === 'json') {
+    if (config.getString('hook.output') === 'json') {
       traceEmit(traceMessage);
     } else {
       traceEmit(`[dt][${traceMessage.timestamp}] ${address} - args: ${JSON.stringify(values)}`);
@@ -3057,7 +3057,7 @@ function interceptRetJava (klass, method, value) {
   javaPerform(function () {
     const System = javaUse(klass);
     System[method].implementation = function (library) {
-      if (config.getString('hook.output').toLowerCase() === 'json') {
+      if (config.getString('hook.output') === 'json') {
         traceEmit({
           source: 'java',
           class: klass,
@@ -3734,8 +3734,12 @@ function evalConfig (args) {
       if (v === '?') {
         return config.helpFor(kv[0]);
       }
-      // set
-      config.set(kv[0], kv[1]);
+      // set (and flatten case for variables except file.log)
+      if (kv[0] === 'file.log') {
+        config.set(kv[0], kv[1]);
+      } else {
+        config.set(kv[0], kv[1].toLowerCase());
+      }
     } else {
       console.error('unknown variable');
     }

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -80,7 +80,7 @@ function javaTraceExample () {
     const System = Java.use('java.lang.System');
     System.loadLibrary.implementation = function (library) {
       try {
-        traceLog('System.loadLibrary ' + library);
+        traceEmit('System.loadLibrary ' + library);
         const loaded = Runtime.getRuntime().loadLibrary0(VMStack.getCallingClassLoader(), library);
         return loaded;
       } catch (e) {
@@ -2546,7 +2546,7 @@ function traceFormat (args) {
         if (config.getBoolean('hook.backtrace')) {
           traceMessage.backtrace = Thread.backtrace(this.context).map(DebugSymbol.fromAddress);
         }
-        traceLog(traceMessage);
+        traceEmit(traceMessage);
       }
     },
     onLeave: function (retval) {
@@ -2562,7 +2562,7 @@ function traceFormat (args) {
         if (config.getBoolean('hook.backtrace')) {
           traceMessage.backtrace = Thread.backtrace(this.context).map(DebugSymbol.fromAddress);
         }
-        traceLog(traceMessage);
+        traceEmit(traceMessage);
       }
     }
   });
@@ -2666,11 +2666,7 @@ function traceEmit (msg) {
       message: msg
     }));
   } else {
-    if (config.getBoolean('hook.verbose')) {
-      send(wrapStanza('log', {
-        message: msg
-      }));
-    }
+    traceLog(msg);
   }
   if (config.getBoolean('hook.logs')) {
     logs.push(msg);
@@ -2745,7 +2741,7 @@ function traceRegs (args) {
     if (config.getBoolean('hook.backtrace')) {
       traceMessage.backtrace = Thread.backtrace(this.context).map(DebugSymbol.fromAddress);
     }
-    traceLog(traceMessage);
+    traceEmit(traceMessage);
   }
   const traceListener = {
     source: 'dtr',
@@ -2829,7 +2825,7 @@ function traceJava (klass, method) {
         result: res,
         values: args
       };
-      traceLog(traceMessage);
+      traceEmit(traceMessage);
       return res;
     };
   });
@@ -2837,6 +2833,10 @@ function traceJava (klass, method) {
 
 function traceQuiet (args) {
   return traceListeners.map(({ address, hits, moduleName, name }) => [address, hits, moduleName + ':' + name].join(' ')).join('\n') + '\n';
+}
+
+function traceEvents() {
+  return {}
 }
 
 function traceJson (args) {
@@ -2980,7 +2980,7 @@ function traceReal (name, addressString) {
       values: values,
     };
     traceListener.hits++;
-    traceLog(traceMessage);
+    traceEmit(traceMessage);
   });
   const traceListener = {
     source: 'dt',
@@ -3024,7 +3024,7 @@ function interceptRetJava (klass, method, value) {
   javaPerform(function () {
     const System = javaUse(klass);
     System[method].implementation = function (library) {
-      traceLog('Intercept return for ' + klass + ' ' + method + ' with ' + value);
+      traceEmit('Intercept return for ' + klass + ' ' + method + ' with ' + value);
       switch (value) {
         case 0: return false;
         case 1: return true;

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -3735,10 +3735,10 @@ function evalConfig (args) {
         return config.helpFor(kv[0]);
       }
       // set (and flatten case for variables except file.log)
-      if (kv[0] === 'file.log') {
-        config.set(kv[0], kv[1]);
-      } else {
+      if (kv[0] !== 'file.log' && typeof kv[1] === 'string') {
         config.set(kv[0], kv[1].toLowerCase());
+      } else {
+        config.set(kv[0], kv[1]);
       }
     } else {
       console.error('unknown variable');

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -2835,10 +2835,6 @@ function traceQuiet (args) {
   return traceListeners.map(({ address, hits, moduleName, name }) => [address, hits, moduleName + ':' + name].join(' ')).join('\n') + '\n';
 }
 
-function traceEvents() {
-  return {}
-}
-
 function traceJson (args) {
   if (args.length === 0) {
     return traceListJson();


### PR DESCRIPTION
As per #252, this PR exposes the `traceEmit` functions to the dt commands, allowing for file redirection.

 A `hook.output` config value can now be set to `json` (default is `simple`), to allow more or less information as you wish.

![image](https://user-images.githubusercontent.com/5285945/93384735-24b96c00-f85d-11ea-928b-f5e081856014.png)

Since the traces now use `traceEmit()`, these will be written to file instead of stdout, if you have set `file.log` to a filepath like so:

`\e file.log=example_trace.log`

