### PR TITLE
Fix writing and "\e/" for frida 14

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -3691,7 +3691,7 @@ function searchValueJson (args, width) {
 }
 
 function evalConfigSearch (args) {
-  const currentRange = Process.getRangeByAddress(r2frida.offset);
+  const currentRange = Process.getRangeByAddress(ptr(r2frida.offset));
   const from = currentRange.base;
   const to = from.add(currentRange.size);
   return `e search.in=raw

--- a/src/agent/io.js
+++ b/src/agent/io.js
@@ -68,7 +68,7 @@ function write (params, data) {
   if (typeof r2frida.hookedWrite === 'function') {
     return r2frida.hookedWrite(params.offset, data);
   }
-  if (config.getBoolean('patch.code') && isExecutable(params.offset)) {
+  if (config.getBoolean('patch.code') && isExecutable(ptr(params.offset))) {
     if (typeof Memory.patchCode === 'function') {
       Memory.patchCode(ptr(params.offset), 1, function (ptr) {
         Memory.writeByteArray(ptr, data);


### PR DESCRIPTION
Trying to write with any "w" command or using "\e/" when using r2frida led to the error `expected a pointer` due to `Process.getRangeByAddress` being passed a number instead of a ptr. This fix simply adds the calls to ptr in the two places affected. 