### PR TITLE
Avoid QuickJS bytecode and use plain JS instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 /io_frida.dylib
 /node_modules/
 /src/_agent.h
-/src/_agent.qjs

--- a/Makefile
+++ b/Makefile
@@ -149,10 +149,10 @@ src/io_frida.o: src/io_frida.c $(FRIDA_SDK) src/_agent.h
 ext/swift-frida/node_modules: ext/swift-frida/index.js ext/swift-frida/index.js
 	cd ext/swift-frida && npm i
 
-src/_agent.h: src/_agent.qjs
+src/_agent.h: src/_agent.js
 	r2 -nfqcpc $< | grep 0x > $@
 
-src/_agent.qjs: src/agent/index.js src/agent/plugin.js node_modules
+src/_agent.js: src/agent/index.js src/agent/plugin.js node_modules
 	npm run build
 
 node_modules: package.json
@@ -212,7 +212,7 @@ android-arm: radare2-android-arm-libs
 		LDFLAGS="-L$(R2A_DIR)/lib $(LDFLAGS)" SO_EXT=so
 
 clean:
-	$(RM) src/*.o src/_agent.qjs src/_agent.h
+	$(RM) src/*.o src/_agent.js src/_agent.h
 	$(RM) -rf $(R2A_DIR)
 
 mrproper: clean

--- a/build.bat
+++ b/build.bat
@@ -27,7 +27,7 @@ for %%i in (%*) do (
 
 call npm install
 cd src
-cat .\_agent.qjs | xxd -i > .\_agent.h || (echo "xxd not in path?" & exit /b 1)
+cat .\_agent.js | xxd -i > .\_agent.h || (echo "xxd not in path?" & exit /b 1)
 
 mkdir frida > nul 2>&1
 cd frida

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "semistandard src/agent/*.js",
     "indent": "semistandard --fix src/agent/*.js",
     "prepare": "npm run build",
-    "build": "frida-compile src/agent -o src/_agent.qjs -bc",
-    "watch": "frida-compile src/agent -o src/_agent.qjs -bcw"
+    "build": "frida-compile src/agent -o src/_agent.js -c",
+    "watch": "frida-compile src/agent -o src/_agent.js -w"
   },
   "license": "LGPL-3.0",
   "dependencies": {

--- a/src/io_frida.c
+++ b/src/io_frida.c
@@ -80,8 +80,6 @@ extern RIOPlugin r_io_plugin_frida;
 static FridaDeviceManager *device_manager = NULL;
 static size_t device_manager_count = 0;
 
-#define QUICKJS_BYTECODE_MAGIC 0x02
-
 #define src__agent__js r_io_frida_agent_code
 
 static const gchar r_io_frida_agent_code[] = {
@@ -372,15 +370,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 		code_size = sizeof (r_io_frida_agent_code) - 1;
 	}
 
-	if (code_size > 0 && code_buf[0] == QUICKJS_BYTECODE_MAGIC) {
-		GBytes *bytecode = (code_malloc_data == NULL)
-			? g_bytes_new_static (code_buf, code_size)
-			: g_bytes_new_with_free_func (code_buf, code_size, free, g_steal_pointer (&code_malloc_data));
-		rf->script = frida_session_create_script_from_bytes_sync (rf->session, bytecode, options, rf->cancellable, &error);
-		g_bytes_unref (bytecode);
-	} else {
-		rf->script = frida_session_create_script_sync (rf->session, code_buf, options, rf->cancellable, &error);
-	}
+	rf->script = frida_session_create_script_sync (rf->session, code_buf, options, rf->cancellable, &error);
 
 	free (code_malloc_data);
 


### PR DESCRIPTION
The format is too volatile to be useful in use-cases where the exact
version of Frida is unknown.