### PR TITLE
Hexdump

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -2357,8 +2357,14 @@ function formatArgs (args, fmt) {
         j--;
         break;
       case 'h':
-        dumps.push(_hexdumpUntrusted(arg));
-        a.push(`dump:${dumps.length}`)
+        let dumpLen = 128;
+        let optionalNumStr = fmt.slice(i+1).match(/^[0-9]*/)[0];
+        if (optionalNumStr.length > 0) {
+			i += optionalNumStr.length;
+			dumpLen = +optionalNumStr;
+		}
+        dumps.push(_hexdumpUntrusted(arg, dumpLen));
+        a.push(`dump:${dumps.length}`);
         break
       case 'x':
         a.push('' + ptr(arg));
@@ -2634,7 +2640,7 @@ function traceFormat (args) {
           if (config.getBoolean('hook.backtrace')) {
             msg += ` backtrace: ${traceMessage.backtrace.toString()}`;
           }
-          for (let i=0; i<this.myDumps.length; i++) msg += `\ndump ${i+1}\n${this.myDumps[i]}`;
+          for (let i=0; i<this.myDumps.length; i++) msg += `\ndump:${i+1}\n${this.myDumps[i]}`;
           traceEmit(msg);
         }
       }

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -24,11 +24,11 @@ const JavaAvailable = Java && Java.available;
 /* globals */
 const pointerSize = Process.pointerSize;
 
-var suspended = false;
-var tracehooks = {};
-var logs = [];
-var traces = {};
-var breakpoints = {};
+let suspended = false;
+const tracehooks = {};
+let logs = [];
+let traces = {};
+let breakpoints = {};
 
 const allocPool = {};
 const pendingCmds = {};
@@ -38,7 +38,7 @@ const specialChars = '`${}~|;#@&<> ()';
 
 function numEval (expr) {
   return new Promise((resolve, reject) => {
-    var symbol = DebugSymbol.fromName(expr);
+    const symbol = DebugSymbol.fromName(expr);
     if (symbol && symbol.name) {
       return resolve(symbol.address);
     }
@@ -231,7 +231,7 @@ const commandHandlers = {
   envj: getOrSetEnvJson,
   dl: dlopen,
   dlf: loadFrameworkBundle,
-  'dlf-':unloadFrameworkBundle,
+  'dlf-': unloadFrameworkBundle,
   dtf: traceFormat,
   dth: traceHook,
   dt: trace,
@@ -383,15 +383,15 @@ function _addAlloc (allocPtr) {
   return key;
 }
 
-function resolveSyscallNumber(name) {
-  const ios = Process.arch === 'arm64'? true: false;
+function resolveSyscallNumber (name) {
+  const ios = Process.arch === 'arm64';
   switch (name) {
-  case 'read':
-    return ios?3:0x2000003;
-  case 'write':
-    return ios?4:0x2000004;
-  case 'exit':
-    return ios?1:0x2000001;
+    case 'read':
+      return ios ? 3 : 0x2000003;
+    case 'write':
+      return ios ? 4 : 0x2000004;
+    case 'exit':
+      return ios ? 1 : 0x2000001;
   }
   return '' + name;
 }
@@ -400,7 +400,7 @@ function dxSyscall (args) {
   if (args.length === 0) {
     return 'Usage dxs [syscallname] [args ...]';
   }
-  const syscallNumber = ''+resolveSyscallNumber(args[0]);
+  const syscallNumber = '' + resolveSyscallNumber(args[0]);
   return dxCall(['syscall', syscallNumber, ...args.slice(1)]);
 }
 
@@ -416,7 +416,7 @@ For example:
 `;
   }
   // push arguments
-  for (var i = 1; i < args.length; i++) {
+  for (let i = 1; i < args.length; i++) {
     if (args[i].substring(0, 2) === '0x') {
       nfArgs.push('pointer');
       nfArgsData.push(ptr(args[i]));
@@ -500,7 +500,7 @@ function disasm (addr, len, initialOldName) {
       disco += ';;; ' + (ds.moduleName ? ds.moduleName : dsName) + '\n';
       oldName = dsName;
     }
-    var comment = '';
+    let comment = '';
     const id = op.opStr.indexOf('#0x');
     if (id !== -1) {
       try {
@@ -563,15 +563,15 @@ function symf (name, ret, arg) {
   }
 }
 
-var _getenv = 0;
-var _setenv = 0;
-var _getpid = 0;
-var _getuid = 0;
-var _dup2 = 0;
-var _readlink = 0;
-var _fstat = 0;
-var _close = 0;
-var _kill = 0;
+let _getenv = 0;
+let _setenv = 0;
+let _getpid = 0;
+let _getuid = 0;
+let _dup2 = 0;
+let _readlink = 0;
+let _fstat = 0;
+let _close = 0;
+let _kill = 0;
 
 if (Process.platform === 'windows') {
   _getenv = sym('getenv', 'pointer', ['pointer']);
@@ -692,11 +692,11 @@ function breakpointExist (addr) {
   return bp && !bp.continue;
 }
 
-var _r2 = null;
-var _r_core_new = null;
-var _r_core_cmd_str = null;
-var _r_core_free = null;
-var _free = null;
+let _r2 = null;
+let _r_core_new = null;
+let _r_core_cmd_str = null;
+let _r_core_free = null;
+let _free = null;
 
 function radareCommandInit () {
   if (_r2) {
@@ -887,7 +887,7 @@ function setBreakpoint (name, address) {
 }
 
 function getCwd () {
-  var _getcwd = 0;
+  let _getcwd = 0;
   if (Process.platform === 'windows') {
     _getcwd = sym('_getcwd', 'pointer', ['pointer', 'int']);
   } else {
@@ -1248,19 +1248,19 @@ function lookupSymbolR2 (args) {
 }
 
 function lookupSymbolManyJson (args) {
-  let res = [];
-  for (let arg of args) {
-    res.push({name:arg, address: lookupSymbol ([arg])});
+  const res = [];
+  for (const arg of args) {
+    res.push({ name: arg, address: lookupSymbol([arg]) });
   }
   return res;
 }
 
 function lookupSymbolMany (args) {
-  return lookupSymbolManyJson (args).map(({address}) => address).join('\n');
+  return lookupSymbolManyJson(args).map(({ address }) => address).join('\n');
 }
 
 function lookupSymbolManyR2 (args) {
-  return lookupSymbolManyJson (args)
+  return lookupSymbolManyJson(args)
     .map(({ name, address }) =>
       ['f', 'sym.' + name, '=', address].join(' '))
     .join('\n');
@@ -1306,7 +1306,7 @@ function lookupSymbolJson (args) {
         address: res
       }];
     }
-    var fcns = DebugSymbol.findFunctionsNamed(symbolName);
+    const fcns = DebugSymbol.findFunctionsNamed(symbolName);
     if (fcns) {
       return fcns.map((f) => { return { name: symbolName, address: f }; });
     }
@@ -1338,7 +1338,7 @@ function listEntrypointJson (args) {
     return false;
   }
   if (Process.platform === 'linux') {
-    var at = DebugSymbol.fromName('main');
+    const at = DebugSymbol.fromName('main');
     if (at) {
       return [at];
     }
@@ -1440,12 +1440,12 @@ function listClassesLoaders (args) {
   if (!JavaAvailable) {
     return 'Error: icL is only available on Android targets.';
   }
-  var res = '';
+  let res = '';
   javaPerform(function () {
     function s2o (s) {
-      var indent = 0;
-      var res = '';
-      for (var ch of s.toString()) {
+      let indent = 0;
+      let res = '';
+      for (const ch of s.toString()) {
         switch (ch) {
           case '[':
             indent++;
@@ -1465,8 +1465,8 @@ function listClassesLoaders (args) {
       }
       return res;
     }
-    var c = Java.enumerateClassLoadersSync();
-    for (var cl in c) {
+    const c = Java.enumerateClassLoadersSync();
+    for (const cl in c) {
       const cs = s2o(c[cl].toString());
       res += cs;
     }
@@ -2289,40 +2289,40 @@ function dlopen (args) {
   let path = args[0];
   if (path.includes('\/r2f\/AppBundle')) {
     const app_path = ObjC.classes.NSBundle.mainBundle().bundlePath();
-    path = path.replace('\/r2f\/AppBundle', app_path);  
-  } 
+    path = path.replace('\/r2f\/AppBundle', app_path);
+  }
   if (path.includes('\/r2f\/AppHome')) {
-    let NSHomeDirectory = new NativeFunction(Module.findExportByName(null, 'NSHomeDirectory'), 'pointer', []);
-    const appHome = new ObjC.Object(NSHomeDirectory()).toString()
-    path = path.replace('\/r2f\/AppHome', appHome);  
-  } 
+    const NSHomeDirectory = new NativeFunction(Module.findExportByName(null, 'NSHomeDirectory'), 'pointer', []);
+    const appHome = new ObjC.Object(NSHomeDirectory()).toString();
+    path = path.replace('\/r2f\/AppHome', appHome);
+  }
   if (path.includes('\/r2f\/Device')) {
     path = path.replace('\/r2f\/AppHome', '\/');
   }
   return Module.load(path);
 }
 
-function loadFrameworkBundle(args) {
+function loadFrameworkBundle (args) {
   const path = args[0];
   const app_path = ObjC.classes.NSBundle.mainBundle().bundlePath();
   const full_path = app_path.stringByAppendingPathComponent_(path);
   const bundle = ObjC.classes.NSBundle.bundleWithPath_(full_path);
   if (bundle.isLoaded()) {
-    console.log("Bundle already loaded");
+    console.log('Bundle already loaded');
     return false;
-  } 
+  }
   return bundle.load();
 }
 
-function unloadFrameworkBundle(args) {
+function unloadFrameworkBundle (args) {
   const path = args[0];
   const app_path = ObjC.classes.NSBundle.mainBundle().bundlePath();
   const full_path = app_path.stringByAppendingPathComponent_(path);
   const bundle = ObjC.classes.NSBundle.bundleWithPath_(full_path);
   if (!bundle.isLoaded()) {
-    console.log("Bundle already unloaded");
+    console.log('Bundle already unloaded');
     return false;
-  } 
+  }
   return bundle.unload();
 }
 
@@ -2337,7 +2337,7 @@ function changeSelinuxContext (args) {
   const con = Memory.allocUtf8String('u:object_r:frida_file:s0');
   const path = Memory.allocUtf8String(file);
 
-  var rv = _setfilecon(path, con);
+  const rv = _setfilecon(path, con);
   return JSON.stringify({ ret: rv.value, errno: rv.errno });
 }
 
@@ -2357,39 +2357,39 @@ function formatArgs (args, fmt) {
         j--;
         break;
       case 'h': {
-			// hexdump pointer target, default length 128
-			// customize length with h<length>, f.e. h16 to dump 16 bytes
-			let dumpLen = 128;
-			let optionalNumStr = fmt.slice(i+1).match(/^[0-9]*/)[0];
-			if (optionalNumStr.length > 0) {
-				i += optionalNumStr.length;
-				dumpLen = +optionalNumStr;
-			}
-			dumps.push(_hexdumpUntrusted(arg, dumpLen));
-			a.push(`dump:${dumps.length} (len=${dumpLen})`);
-		}
-        break
+        // hexdump pointer target, default length 128
+        // customize length with h<length>, f.e. h16 to dump 16 bytes
+        let dumpLen = 128;
+        const optionalNumStr = fmt.slice(i + 1).match(/^[0-9]*/)[0];
+        if (optionalNumStr.length > 0) {
+          i += optionalNumStr.length;
+          dumpLen = +optionalNumStr;
+        }
+        dumps.push(_hexdumpUntrusted(arg, dumpLen));
+        a.push(`dump:${dumps.length} (len=${dumpLen})`);
+      }
+        break;
       case 'H': {
-			// hexdump pointer target, default length 128
-			// use length from other funtion arg with H<arg number>, f.e. H0 to dump '+args[0]' bytes
-			let dumpLen = 128;
-			let optionalNumStr = fmt.slice(i+1).match(/^[0-9]*/)[0];
-			if (optionalNumStr.length > 0) {
-				i += optionalNumStr.length;
-				let posLenArg = +optionalNumStr;
-				if (posLenArg !== j) {
-					// only adjust dump length, if the length param isn't the dump address itself
-					dumpLen = +args[posLenArg];
-				}
-			}
-			// limit dumpLen, to avoid oversized dumps, caused by  accidentally parsing pointer agrs as length
-			// set length limit to 64K for now
-			const lenLimit = 0x10000;
-			dumpLen = dumpLen > lenLimit ? lenLimit : dumpLen;
-			dumps.push(_hexdumpUntrusted(arg, dumpLen));
-			a.push(`dump:${dumps.length} (len=${dumpLen})`);
-		}
-        break
+        // hexdump pointer target, default length 128
+        // use length from other funtion arg with H<arg number>, f.e. H0 to dump '+args[0]' bytes
+        let dumpLen = 128;
+        const optionalNumStr = fmt.slice(i + 1).match(/^[0-9]*/)[0];
+        if (optionalNumStr.length > 0) {
+          i += optionalNumStr.length;
+          const posLenArg = +optionalNumStr;
+          if (posLenArg !== j) {
+            // only adjust dump length, if the length param isn't the dump address itself
+            dumpLen = +args[posLenArg];
+          }
+        }
+        // limit dumpLen, to avoid oversized dumps, caused by  accidentally parsing pointer agrs as length
+        // set length limit to 64K for now
+        const lenLimit = 0x10000;
+        dumpLen = dumpLen > lenLimit ? lenLimit : dumpLen;
+        dumps.push(_hexdumpUntrusted(arg, dumpLen));
+        a.push(`dump:${dumps.length} (len=${dumpLen})`);
+      }
+        break;
       case 'x':
         a.push('' + ptr(arg));
         break;
@@ -2439,7 +2439,7 @@ function formatArgs (args, fmt) {
         break;
     }
   }
-  return {args: a, dumps: dumps};
+  return { args: a, dumps: dumps };
 }
 
 function cloneArgs (args, fmt) {
@@ -2462,7 +2462,7 @@ function cloneArgs (args, fmt) {
 
 function _hexdumpUntrusted (addr, len) {
   try {
-	  if (typeof len === 'number') return hexdump(addr, {length: len});
+	  if (typeof len === 'number') return hexdump(addr, { length: len });
 	  else return hexdump(addr);
   } catch (e) {
     return `hexdump at ${addr} failed: ${e}`;
@@ -2571,7 +2571,7 @@ function traceHook (args) {
   if (args.length === 0) {
     return JSON.stringify(tracehooks, null, 2);
   }
-  var arg = args[0];
+  const arg = args[0];
   if (arg !== undefined) {
     tracehookSet(arg, args.slice(1).join(' '));
   }
@@ -2610,7 +2610,7 @@ function traceFormat (args) {
       if (!traceOnEnter) {
         this.keepArgs = cloneArgs(args, format);
       } else {
-		let fa = formatArgs(args, format);
+        const fa = formatArgs(args, format);
         this.myArgs = fa.args;
         this.myDumps = fa.dumps;
       }
@@ -2635,14 +2635,14 @@ function traceFormat (args) {
           if (config.getBoolean('hook.backtrace')) {
             msg += ` backtrace: ${traceMessage.backtrace.toString()}`;
           }
-          for (let i=0; i<this.myDumps.length; i++) msg += `\ndump:${i+1}\n${this.myDumps[i]}`;
+          for (let i = 0; i < this.myDumps.length; i++) msg += `\ndump:${i + 1}\n${this.myDumps[i]}`;
           traceEmit(msg);
         }
       }
     },
     onLeave: function (retval) {
       if (!traceOnEnter) {
-   		let fa = formatArgs(this.keepArgs, format);
+   		const fa = formatArgs(this.keepArgs, format);
         this.myArgs = fa.args;
         this.myDumps = fa.dumps;
 
@@ -2664,7 +2664,7 @@ function traceFormat (args) {
           if (config.getBoolean('hook.backtrace')) {
             msg += ` backtrace: ${traceMessage.backtrace.toString()}`;
           }
-          for (let i=0; i<this.myDumps.length; i++) msg += `\ndump:${i+1}\n${this.myDumps[i]}`;
+          for (let i = 0; i < this.myDumps.length; i++) msg += `\ndump:${i + 1}\n${this.myDumps[i]}`;
           traceEmit(msg);
         }
       }
@@ -2905,7 +2905,7 @@ function dumpJavaArguments (args) {
 
 function traceJavaConstructors (className) {
   javaPerform(function () {
-    var foo = Java.use(className).$init.overloads;
+    const foo = Java.use(className).$init.overloads;
     foo.forEach((over) => {
       over.implementation = function () {
         console.log('dt', className, '(', dumpJavaArguments(arguments), ')');
@@ -2965,7 +2965,7 @@ function traceJson (args) {
   }
   return new Promise(function (resolve, reject) {
     (function pull () {
-      var arg = args.pop();
+      const arg = args.pop();
       if (arg === undefined) {
         return resolve('');
       }
@@ -3007,11 +3007,11 @@ function arrayBufferToHex (arrayBuffer) {
     throw new TypeError('Expected input to be an ArrayBuffer');
   }
 
-  var view = new Uint8Array(arrayBuffer);
-  var result = '';
-  var value;
+  const view = new Uint8Array(arrayBuffer);
+  let result = '';
+  let value;
 
-  for (var i = 0; i < view.length; i++) {
+  for (let i = 0; i < view.length; i++) {
     value = view[i].toString(16);
     result += (value.length === 1 ? '0' + value : value);
   }
@@ -3023,10 +3023,10 @@ function arrayBufferToHex (arrayBuffer) {
 function tracehook (address, args) {
   const at = nameFromAddress(address);
   const th = tracehooks[at];
-  var fmtarg = [];
+  const fmtarg = [];
   if (th && th.format) {
     for (const fmt of th.format.split(' ')) {
-      var [k, v] = fmt.split(':');
+      const [k, v] = fmt.split(':');
       switch (k) {
         case 'i':
         // console.log('int', args[v]);
@@ -3519,7 +3519,7 @@ function padPointer (value) {
 }
 
 const requestHandlers = {
-  safeio: () => { r2frida.safeio = true },
+  safeio: () => { r2frida.safeio = true; },
   read: io.read,
   write: io.write,
   state: state,
@@ -4209,7 +4209,6 @@ global.r2frida.logs = logs;
 global.r2frida.log = traceLog;
 global.r2frida.emit = traceEmit;
 global.r2frida.safeio = NeedsSafeIo;
-
 
 function sendCommand (cmd, serial) {
   function sendIt () {

--- a/src/agent/io.js
+++ b/src/agent/io.js
@@ -5,7 +5,6 @@ const config = require('./config');
 
 let cachedRanges = [];
 
-
 function read (params) {
   const { offset, count, fast } = params;
   if (r2frida.hookedRead !== null) {
@@ -14,12 +13,12 @@ function read (params) {
   if (r2frida.safeio) {
     if (cachedRanges.length == 0) {
       cachedRanges = Process.enumerateRanges('').map(
-        (map) => [ map.base, ptr(map.base).add(map.size) ]);
+        (map) => [map.base, ptr(map.base).add(map.size)]);
     }
     // TODO: invalidate ranges at some point to refresh
     // process.nextTick(() => { cachedRanges = null; }
     const o = ptr(offset);
-    for (let map of cachedRanges) {
+    for (const map of cachedRanges) {
       if (o.compare(map[0]) >= 0 && o.compare(map[1]) < 0) {
         let left = count;
         if (o.add(count).compare(map[1]) > 0) {

--- a/src/io_frida.c
+++ b/src/io_frida.c
@@ -715,6 +715,8 @@ static char *__system_continuation(RIO *io, RIODesc *fd, const char *command) {
 		io->cb_printf ("  c  = show value as a string (char)\n");
 		io->cb_printf ("  i  = show decimal argument\n");
 		io->cb_printf ("  z  = show pointer to string\n");
+		io->cb_printf ("  h  = hexdump from pointer (optinal length, h16 to dump 16 bytes)\n");
+		io->cb_printf ("  H  = hexdump from pointer (optinal position of length argument, H1 to dump args[1] bytes)\n");
 		io->cb_printf ("  s  = show string in place\n");
 		io->cb_printf ("  O  = show pointer to ObjC object\n");
 		io->cb_printf ("Undocumented: Z, S\n");

--- a/src/io_frida.c
+++ b/src/io_frida.c
@@ -715,8 +715,8 @@ static char *__system_continuation(RIO *io, RIODesc *fd, const char *command) {
 		io->cb_printf ("  c  = show value as a string (char)\n");
 		io->cb_printf ("  i  = show decimal argument\n");
 		io->cb_printf ("  z  = show pointer to string\n");
-		io->cb_printf ("  h  = hexdump from pointer (optinal length, h16 to dump 16 bytes)\n");
-		io->cb_printf ("  H  = hexdump from pointer (optinal position of length argument, H1 to dump args[1] bytes)\n");
+		io->cb_printf ("  h  = hexdump from pointer (optional length, h16 to dump 16 bytes)\n");
+		io->cb_printf ("  H  = hexdump from pointer (optional position of length argument, H1 to dump args[1] bytes)\n");
 		io->cb_printf ("  s  = show string in place\n");
 		io->cb_printf ("  O  = show pointer to ObjC object\n");
 		io->cb_printf ("Undocumented: Z, S\n");


### PR DESCRIPTION
# Added customizable hexdump functionality for formatted tracing.

## Adjusted help screen

```
[0x00000000]> \dtf?
Usage: dtf [format] || dtf [addr] [fmt]
  ^  = trace onEnter instead of onExit
  +  = show backtrace on trace
 p/x = show pointer in hexadecimal
  c  = show value as a string (char)
  i  = show decimal argument
  z  = show pointer to string
  h  = hexdump from pointer (optinal length, h16 to dump 16 bytes)
  H  = hexdump from pointer (optinal position of length argument, H1 to dump args[1] bytes)
  s  = show string in place
  O  = show pointer to ObjC object
Undocumented: Z, S
 dtf    trace format
```

# Examples

Example function to trace `0x87544aa5(uint8_t* byteBuf, int bufLen, ...)`

## 1. Hexdump for args[0] (default length 128), int for args[1]

```
[0x00000000]> \dtf 0x87544aa5 hi
true
[0x00000000]> [dtf onLeave][Wed Jan 13 2021 11:24:16 GMT+0100] 0x87544aa5@0x87544aa5 - args: dump:1 (len=128), 1503. Retval: 0x0 backtrace: 0x87544cb4 libEncryptor.so!0x3cb4,0x92fcc677 base.odex!0x4c5677
dump:1
           0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F  0123456789ABCDEF
a8f07200  1f 8b 08 00 00 00 00 00 00 00 ed 58 db 72 db 36  ...........X.r.6
a8f07210  10 fd 15 0e 9f 92 19 49 c6 8d 20 e1 3c 74 9c 38  .......I.. .<t.8
a8f07220  4d db c4 bd d9 4d 1f e2 0e 06 04 21 0a 11 6f 01  M....M.....!..o.
a8f07230  49 29 b2 27 ff de 05 29 c9 97 8c 3b 4e fd e2 cc  I).'...)...;N...
a8f07240  d8 7e 21 16 c0 62 f7 ec 39 0b 52 97 61 51 e7 32  .~!..b..9.R.aQ.2
a8f07250  53 9d 0a 0f 3f 5c 86 aa 28 ea b5 6c c2 c3 29 9e  S...?\..(..l..).
a8f07260  84 5a e9 85 91 ba ae 3a 53 75 b2 30 55 de 2d c2  .Z.....:Su.0U.-.
a8f07270  43 1a a3 08 25 62 37 bd b0 9d ac e7 f3 af ec dd  C...%b7.........
```

## 2. Hexdump for args[0] with fixed length 32, int for args[1]

```
[0x00000000]> \dtf 0x87544aa5 h32i
true
[0x00000000]> [dtf onLeave][Wed Jan 13 2021 11:25:50 GMT+0100] 0x87544aa5@0x87544aa5 - args: dump:1 (len=32), 875. Retval: 0x0 backtrace: 0x87544cb4 libEncryptor.so!0x3cb4,0x92fcc677 base.odex!0x4c5677
dump:1
           0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F  0123456789ABCDEF
8b325300  1f 8b 08 00 00 00 00 00 00 00 7d 54 db 6e dc 36  ..........}T.n.6
8b325310  10 fd 15 41 4f 09 b0 92 79 13 45 da 4f 4e d1 a6  ...AO...y.E.ON..
[0x00000000]> 
```

## 3. Hexdump for args[0] with length given by args[1], int for args[1]

Note on user error protections:

- if the argument position with the dump offset equals the argument position which should be regarded as length (e.g. `\dtf offset H0i`), the dump length defaults to 128
- to avoid accidentally parsing oversized length from parameters which do not hold a length (e.g. pointer parameters), the hexdump length limit is hardcoded to 0x10000, for now

```
[0x00000000]> \dtf 0x87544aa5 H1i
true
[0x00000000]> [dtf onLeave][Wed Jan 13 2021 11:30:16 GMT+0100] 0x87544aa5@0x87544aa5 - args: dump:1 (len=1466), 1466. Retval: 0x0 backtrace: 0x87544cb4 libEncryptor.so!0x3cb4,0x92fcc677 base.odex!0x4c5677
dump:1
           0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F  0123456789ABCDEF
89507800  1f 8b 08 00 00 00 00 00 00 00 ed 56 4d 73 db 36  ...........VMs.6
89507810  10 fd 2b 1c 9e 92 19 49 06 40 10 04 94 43 c7 89  ..+....I.@...C..
89507820  d3 b4 4d dc 2f bb e9 21 ee 60 40 10 a2 10 f1 2b  ..M./..!.`@....+
89507830  20 29 45 f6 f8 bf 77 41 4a b2 9d 8c 3b 69 72 71   )E...wAJ...;irq
89507840  66 2c 5d 88 05 b0 d8 7d fb de 02 57 61 51 e7 32  f,]....}...WaQ.2
89507850  53 9d 0a e7 ef ae 42 55 14 f5 46 36 e1 7c 8a 27  S.....BU..F6.|.'
89507860  a1 56 7a 69 a4 ae ab ce 54 9d 2c 4c 95 77 cb 70  .Vzi....T.,L.w.p
89507870  1e 25 28 46 5c ec a7 97 b6 93 f5 62 f1 99 bd db  .%(F\......b....
89507880  36 26 9c 93 49 98 d5 9b aa a8 55 26 3b d5 ae 64  6&..I.....U&;..d
89507890  d5 97 e1 1c 4d 42 53 a9 b4 30 52 f5 de 25 f6 63  ....MBS..0R..%.c
895078a0  ed b6 4d 27 d7 c6 b5 b6 ae 76 b6 4c 3a f3 41 76  ..M'.....v.L:.Av
895078b0  30 62 18 c5 51 94 b0 44 d0 08 66 9c 83 b8 32 33  0b..Q..D..f...23
895078c0  b8 5a 58 70 b4 32 db 70 1e ae 51 82 28 8d 90 ff  .ZXp.2.p..Q.(...
895078d0  a5 7d b2 4c b9 78 5f a6 6c f9 1e 61 57 27 90 68  .}.L.x_.l..aW'.h
895078e0  ba ed cc 5a 63 19 53 d4 48 82 59 c2 98 08 27 e1  ...Zc.S.H.Y...'.
895078f0  52 55 b2 5d ca 16 4e a2 93 d0 d6 70 2c 04 dc da  RU.]..N....p,...
89507900  4b 38 21 62 82 d0 38 b9 31 77 b6 04 33 24 6a db  K8!b..8.1w..3$j.
89507910  21 7e 09 d1 8c 80 81 41 3b 7d 67 bc b4 bf 28 bd  !~.....A;}g...(.
89507920  1a 4d 10 6b 21 ef 84 5e c0 91 6a 37 24 c8 1b 00  .M.k!..^..j7$...
89507930  28 e3 e4 01 b3 31 84 9b 89 11 55 ef db 97 6d 1c  (....1....U...m.
89507940  85 a5 c9 ac 92 e3 0a 48 a6 32 dd fd 45 ab 9d 95  .......H.2..E...
89507950  f7 15 ae 91 75 63 aa 43 ac 4e 6d be 11 d6 01 ae  ....uc.C.Nm.....
89507960  f1 b4 31 11 cc b9 48 b8 88 10 61 22 d9 cd ef 32  ..1...H...a"...2
89507970  3b 64 3a 42 ef f4 98 a6 33 da d8 b5 f9 8c 07 11  ;d:B....3.......

... snip (dump length is 1466 bytes) ...
``` 