### PR TITLE
Loading Foundation natively to fix early instrumentation error when spawning

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -602,7 +602,7 @@ const _setfilecon = symf('setfilecon', 'int', ['pointer', 'pointer']);
 if (Process.platform === 'darwin') {
   // required for early instrumentation
   try {
-    Module.load(['/System/Library/Frameworks/Foundation.framework/Foundation']);
+    Module.load('/System/Library/Frameworks/Foundation.framework/Foundation');
   } catch (e) {
     // ignored
   }

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -602,7 +602,7 @@ const _setfilecon = symf('setfilecon', 'int', ['pointer', 'pointer']);
 if (Process.platform === 'darwin') {
   // required for early instrumentation
   try {
-    dlopen(['/System/Library/Frameworks/Foundation.framework/Foundation']);
+    Module.load(['/System/Library/Frameworks/Foundation.framework/Foundation']);
   } catch (e) {
     // ignored
   }


### PR DESCRIPTION
Loading Foundation natively because it is needed to work before any management of the virtual paths.