### PR TITLE
Intercept Java boolean (true and false)

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -196,7 +196,7 @@ const commandHandlers = {
   dth: [trace.traceHook, 'list or add trace hook'],
   t: [swift.swiftTypes, 'list swift types'],
   't*': swift.swiftTypesR2,
-  dt: [trace.trace, 'innject a trace in the given native address (or java:method)', '([addr])'],
+  dt: [trace.trace, 'inject a trace in the given native address (or java:method)', '([addr])'],
   dtj: trace.traceJson,
   dtq: trace.traceQuiet,
   'dt*': trace.traceR2,
@@ -221,6 +221,8 @@ const commandHandlers = {
   dif: [interceptor.interceptFunHelp, 'intercept function'],
   // intercept ret function and dont call the function
   dis: [interceptor.interceptRetString, 'intercept return string', '[addr]'],
+  dibf: [interceptor.interceptRetFalse, 'intercept return boolean false', '[java:]'],
+  dibt: [interceptor.interceptRetTrue, 'intercept return boolean true', '[java:]'],
   di0: [interceptor.interceptRet0, 'intercept function call with a return 0', '[addr|java:]'],
   di1: [interceptor.interceptRet1, 'intercept function with a return 1', '[addr|java:]'],
   dii: [interceptor.interceptRetInt, 'force early return with given number', '[addr] [num]'],

--- a/src/agent/lib/debug/interceptor.js
+++ b/src/agent/lib/debug/interceptor.js
@@ -5,7 +5,7 @@ const java = require('../java');
 const utils = require('../utils');
 
 function interceptHelp (args) {
-  return 'Usage: di[0,1,-1,s,v] [addr] : intercepts function method and replace the return value.\n' /
+  return 'Usage: di[0,1,-1,s,v] [addr] : intercept function method and replace the return value.\n' /
   'di0 0x808080  # when program calls this address, the original function is not called, then return value is replaced.\n' /
   'div java:org.ex.class.method  # when program calls this address, the original function is not called and no value is returned.\n';
 }
@@ -20,6 +20,16 @@ function interceptFunHelp (args) {
 function interceptRetString (args) {
   const target = args[0];
   return _interceptRet(target, args[1]);
+}
+
+function interceptRetFalse (args) {
+  const target = args[0];
+  return _interceptRet(target, false);
+}
+
+function interceptRetTrue (args) {
+  const target = args[0];
+  return _interceptRet(target, true);
 }
 
 function interceptRet0 (args) {
@@ -113,6 +123,8 @@ module.exports = {
   interceptHelp,
   interceptFunHelp,
   interceptRetString,
+  interceptRetFalse,
+  interceptRetTrue,
   interceptRet0,
   interceptRet1,
   interceptRetInt,

--- a/src/agent/lib/java/index.js
+++ b/src/agent/lib/java/index.js
@@ -203,6 +203,8 @@ function interceptRetJava (klass, method, value) {
         case 0: return false;
         case 1: return true;
         case -1: return -1; // TODO should throw an error?
+        case true: return Java.use("java.lang.Boolean").$new(true);
+        case false: return Java.use("java.lang.Boolean").$new(false);
         case null: return;
       }
       return value;

--- a/src/io_frida.c
+++ b/src/io_frida.c
@@ -1005,6 +1005,8 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 		"!!!:dc",
 		"!!!:di",
 		"!!!:dii",
+		"!!!:dibt",
+		"!!!:dibf",
 		"!!!:di0",
 		"!!!:di1",
 		"!!!:di-1",
@@ -1060,7 +1062,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 	} else {
 		R_LOG_INFO("Using safe io mode.");
 	}
-	
+
 	return fd;
 
 error:
@@ -1103,7 +1105,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *command) {
 	if (!io || !fd || !command) {
 		return NULL;
 	}
-	
+
 	return __system_continuation (io, fd, command);
 }
 


### PR DESCRIPTION
I'd like to return Java boolean types (true or false) with the command:

```sh
[0x00000000]> :dibf java:com.scottyab.rootbeer.RootBeer.isRooted
```

Usage:
```sh
[0x00000000]> :di?
:di                       debug intercept commands
:di-1                     force function to return -1
:di0 [addr|java:]         intercept function call with a return 0
:di1 [addr|java:]         intercept function with a return 1
:dibf [java:]             intercept return boolean false
:dibt [java:]             intercept return boolean true
:dif                      intercept function
:dif-1 [addr]             replace function return with -1
:dif0 [addr]              replace function return 0 (after running the function code)
:dif1 [addr]              return 1 after running function
:difi [addr] [num]        replace function return int
:difs [addr] [str]        replace function return string
:dii [addr] [num]         force early return with given number
:dis [addr]               intercept return string
:div                      early return for a void function()
```

Working but same result as `:di0` 
```sh
[0x00000000]> :dibf java:com.scottyab.rootbeer.RootBeer.checkForSuBinary
[0x00000000]> [JAVA TRACE][Wed Nov 02 2022 00:53:16 GMT+0100 (CET)] Intercept return for com.scottyab.rootbeer.RootBeer:checkForSuBinary with false
```