### PR TITLE
Add :di sub-commands to revert previous hooks

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -236,6 +236,8 @@ const commandHandlers = {
     dii: [interceptor.interceptRetInt, 'force early return with given number', '[addr] [num]'],
     'di-1': [interceptor.interceptRet_1, 'force function to return -1'],
     div: [interceptor.interceptRetVoid, 'early return for a void function()'],
+    'di-*': [interceptor.interceptDetachAll, 'remove (detach) all interceptor handles'],
+    dir: [interceptor.interceptRevert, 'revert a trace at the given function', '[addr|java:]'],
     // intercept ret after calling the function
     difs: [interceptor.interceptFunRetString, 'replace function return string', '[addr] [str]'],
     dif0: [interceptor.interceptFunRet0, 'replace function return 0 (after running the function code)', '[addr]'],

--- a/src/agent/lib/debug/interceptor.ts
+++ b/src/agent/lib/debug/interceptor.ts
@@ -117,6 +117,17 @@ function _interceptFunRet(target: string, value: string | number, paramTypes: st
     });
 }
 
+export function interceptDetachAll(args: string[]) {
+    Interceptor.detachAll();
+}
+
+export function interceptRevert(args: string[]) {
+    if (args.length > 0) {
+        const p = getPtr(args[0])
+        Interceptor.revert(p)
+    }
+}
+
 export default {
     interceptHelp,
     interceptFunHelp,
@@ -132,5 +143,7 @@ export default {
     interceptFunRet0,
     interceptFunRet1,
     interceptFunRetInt,
-    interceptFunRet_1
+    interceptFunRet_1,
+    interceptDetachAll,
+    interceptRevert
 };


### PR DESCRIPTION
Adds two commands:

- `:di-*` to invoke Interceptor.detachAll()
- `:dir <ptr|symbol>` which reverts a previously replaced function. Necessary to undo the use of `:di1` etc