### PR TITLE
Fix backtraces being ignored unless env var is set

### DIFF
--- a/src/agent/lib/debug/trace.ts
+++ b/src/agent/lib/debug/trace.ts
@@ -65,14 +65,14 @@ export function traceFormat(args: any) {
                     timestamp: new Date(),
                     values: this.myArgs
                 };
-                if (config.getBoolean('hook.backtrace')) {
+                if (config.getBoolean('hook.backtrace') || this.myBacktrace != undefined) {
                     traceMessage.backtrace = Thread.backtrace(this.context).map(DebugSymbol.fromAddress);
                 }
                 if (config.getString('hook.output') === 'json') {
                     log.traceEmit(JSON.stringify(traceMessage));
                 } else {
                     let msg = `[dtf onEnter][${traceMessage.timestamp}] ${name}@${address} - args: ${this.myArgs.join(', ')}`;
-                    if (config.getBoolean('hook.backtrace')) {
+                    if (config.getBoolean('hook.backtrace') || this.myBacktrace != undefined) {
                         msg += ` backtrace: ${traceMessage.backtrace.toString()}`;
                     }
                     for (let i = 0; i < this.myDumps.length; i++) {


### PR DESCRIPTION
Currently r2f only includes a backtrace if `e hook.backtrace` is set.
However, `:dtf` has a format specifier option (`+`) that is meant to include a backtrace.

This fixes the code so that `+` will get a backtrace, even if `hook.backtrace` is not set.