### PR TITLE
Fix the output formatting of :db

### DIFF
--- a/src/agent/lib/debug/index.ts
+++ b/src/agent/lib/debug/index.ts
@@ -248,7 +248,7 @@ export function sendSignal(args: string[]) {
 function _breakpointList(args: string[]) {
     for (const [address, bp] of newBreakpoints.entries()) {
         if (bp.patches[0].address.equals(ptr(address))) {
-            console.log(address);
+            console.log(`${address}\n`);
         }
     }
 }


### PR DESCRIPTION
As the title suggests, this is a small formatting fix.
Currently the output looks like:
`0xfoobar0xdeadbeef` so this PR simply adds a newline.