### PR TITLE
WIP: Implement a step command via agent debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "LGPL-3.0",
       "devDependencies": {
         "@frida/events": "^4.0.4",
-        "@types/frida-gum": "^18.5.1",
+        "@types/frida-gum": "^18.7.0",
         "@types/node": "^20.0.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
@@ -465,10 +465,11 @@
       }
     },
     "node_modules/@types/frida-gum": {
-      "version": "18.5.1",
-      "resolved": "https://registry.npmjs.org/@types/frida-gum/-/frida-gum-18.5.1.tgz",
-      "integrity": "sha512-99geyCbWB+YBCqxcO+ue7dJUQJti7kQ5CHGQtKoz0ENtRswKULGMFKW6QgL657sMiztqhcDHWJjYSPv5GKT1ig==",
-      "dev": true
+      "version": "18.7.0",
+      "resolved": "https://registry.npmjs.org/@types/frida-gum/-/frida-gum-18.7.0.tgz",
+      "integrity": "sha512-HhBomXE23fLDAWXEKi3BjJLrlH9wAv9IEQNfO/PaYHQNNbh0Bi06gx6JbXTspVpbqlbVqkWAuU7n6HaS9B6yXA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -2418,9 +2419,9 @@
       }
     },
     "@types/frida-gum": {
-      "version": "18.5.1",
-      "resolved": "https://registry.npmjs.org/@types/frida-gum/-/frida-gum-18.5.1.tgz",
-      "integrity": "sha512-99geyCbWB+YBCqxcO+ue7dJUQJti7kQ5CHGQtKoz0ENtRswKULGMFKW6QgL657sMiztqhcDHWJjYSPv5GKT1ig==",
+      "version": "18.7.0",
+      "resolved": "https://registry.npmjs.org/@types/frida-gum/-/frida-gum-18.7.0.tgz",
+      "integrity": "sha512-HhBomXE23fLDAWXEKi3BjJLrlH9wAv9IEQNfO/PaYHQNNbh0Bi06gx6JbXTspVpbqlbVqkWAuU7n6HaS9B6yXA==",
       "dev": true
     },
     "@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@frida/events": "^4.0.4",
-    "@types/frida-gum": "^18.5.1",
+    "@types/frida-gum": "^18.7.0",
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -70,6 +70,7 @@ const commandHandlers = {
     'e*': [config.evalConfigR2, 'display eval config vars in r2 format'],
     'e/': [config.evalConfigSearch, 'eval config search (?)'],
     db: [debug.breakpointNative, 'list or add a native breakpoint', '[addr]'],
+    ds: [debug.breakpointStep, 'step to next instruction'],
     dbj: debug.breakpointJson,
     dbc: [debug.breakpointNativeCommand, 'associate an r2 command when the native breakpoint is hit', '[addr] [cmd]'],
     'db-': [debug.breakpointUnset, 'unset the native breakpoint in the given address', '[addr]'],

--- a/src/agent/lib/debug/index.ts
+++ b/src/agent/lib/debug/index.ts
@@ -327,12 +327,15 @@ export function breakpointStep() {
         const target = nextAddress.toString();
         console.log(`Stepping to ${target}\n`);
         _breakpointSet([target]);
-
-        console.log("Attempting to continue (:dc)\n");
-        breakpointContinue([]);
+        setTimeout(() => {
+            breakpointUnset([target]);
+        }, 1000);
     } else {
         console.log("Couldn't figure out the next address...\n");
     }
+
+    console.log("Attempting to continue (:dc)\n");
+    breakpointContinue([]);
 }
 
 export function breakpointJson() {

--- a/src/agent/lib/debug/index.ts
+++ b/src/agent/lib/debug/index.ts
@@ -284,7 +284,9 @@ export function breakpointStep() {
     const pc = currentThreadContext.pc;
 
     // We need to unpatch pc, to be able to parse the instruction...
-    breakpointUnset([pc.toString()]);
+    if (newBreakpoints.has(pc.toString())) {
+        breakpointUnset([pc.toString()]);
+    }
 
     const currentInstruction = Instruction.parse(pc);
     const { mnemonic, next, opStr } = currentInstruction;


### PR DESCRIPTION
This is an attempt to add a step feature to the existing agent based breakpoint functionality (`:db`), by calculating the next instruction and setting an ephemeral breakpoint there.

I tried to have the code automatically continue, but the app behaves weird. Some times it would work and sometimes hang, so unless you have ideas, we'd use this like so:

```
> :db 0xdeadbeef

breakpoint 0xdeadbeef hit

> :ds
Setting breakpoint to 0x...

> :dc
```