### PR TITLE
Improved help message & feedback for :ies

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -96,7 +96,7 @@ const commandHandlers = {
     ie: [info.listEntrypoint, 'show entrypoint of binary in current offset'],
     ieq: info.listEntrypointQuiet,
     'ie*': info.listEntrypointR2,
-    ies: info.listEntrypointSymbols,
+    ies: [info.listEntrypointSymbols, "List the potential entrypoints of the binary (Darwin only)"],
     iej: info.listEntrypointJson,
     afs: [anal.analFunctionSignature, 'Show function signature', '[klass] [method]'],
     ii: [info.listImports, 'list imports'],

--- a/src/agent/lib/info/index.ts
+++ b/src/agent/lib/info/index.ts
@@ -249,6 +249,9 @@ export function listEntrypointSymbols(args: string[]): string {
                 }
             });
         });
+    } else {
+        console.log("This command is only available on darwin.");
+        return "";
     }
 
     if (symbols.length === 0) {


### PR DESCRIPTION
PR provides:

1. Basic help message for `:ies`
2. A message via console out that this is a darwin only command if the target is not darwin.