### PR TITLE
fix: typo in the file io_frida.c

### DIFF
--- a/src/io_frida.c
+++ b/src/io_frida.c
@@ -1504,7 +1504,7 @@ static void exec_pending_cmd_if_needed(RIOFrida * rf) {
 		return;
 	}
 #if R2_VERSION_NUMBER >= 50909
-	char *output = COREBIND (rf->io).cmdStr (rf->r2core, rf->pending_cmd->cmd_string);
+	char *output = COREBIND (rf->io).cmdstr (rf->r2core, rf->pending_cmd->cmd_string);
 #else
 	char *output = COREBIND (rf->io).cmdstr (rf->r2core, rf->pending_cmd->cmd_string);
 #endif


### PR DESCRIPTION
It is a simple typo in io_frida.c. 

## Typo

`cmdStr` => `cmdstr`