### PR TITLE
fix: remove :ie* to avoid crash during init

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -537,7 +537,6 @@ e anal.autoname=true
 e cmd.fcn.new=aan
 .:i*
 s r2f.modulebase
-.:ie*
 .:dmm*
 .:dm*
 .:il*


### PR DESCRIPTION
## Fix

 remove `:ie*` to avoid crash during init