### PR TITLE
feat: add function to execute and display system commands

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -637,7 +637,7 @@ function getHelpMessage(prefix: string): string {
 
 function perform(params: any) {
     let { command } = params;
-    
+
     if (command.startsWith("!!")) {
         command = "!! " + command.substr(2);
     } else if (command.startsWith("!")) {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -74,6 +74,7 @@ const commandHandlers = {
     ".": [null, "Run Frida script in agent side", "[path]"], // this is implemented in C
     eval: [expr.evalCode, "evaluate Javascript code in agent side", "[code]"],
     "!": [system.runSystemCommand, "execute program with system"],
+    "!!": [system.runSystemCommandAsString, "execute system command"],
     "?": [expr.evalNum, "evaluate number"],
     "?e": [echo, "print message"],
     "?E": [uiAlert, "popup alert dialog on target app"],
@@ -636,9 +637,13 @@ function getHelpMessage(prefix: string): string {
 
 function perform(params: any) {
     let { command } = params;
-    if (command.startsWith("!")) {
+    
+    if (command.startsWith("!!")) {
+        command = "!! " + command.substr(2);
+    } else if (command.startsWith("!")) {
         command = "! " + command.substr(1);
     }
+
     if (command.startsWith("{")) {
         return r2pipe2(command);
     }

--- a/src/agent/lib/debug/system.ts
+++ b/src/agent/lib/debug/system.ts
@@ -23,3 +23,45 @@ export function runSystem(command: string): string | null {
 export function runSystemCommand(args: string[]): string | null {
     return runSystem(args.join(" "));
 }
+
+
+export function runCommandAsString(command: string): string | null {
+
+    const popenSymbol = getGlobalExportByName("popen");
+    const fgetsSymbol = getGlobalExportByName("fgets");
+    const pcloseSymbol = getGlobalExportByName("pclose");
+
+    if (popenSymbol !== null && fgetsSymbol !== null && pcloseSymbol !== null) {
+        const popen = new NativeFunction(popenSymbol, "pointer", ["pointer", "pointer"]);
+        const fgets = new NativeFunction(fgetsSymbol, "pointer", ["pointer", "int", "pointer"]);
+        const pclose = new NativeFunction(pcloseSymbol, "int", ["pointer"]);
+
+        const libcCommand = Memory.allocUtf8String(command);
+        const libcCommandMode = Memory.allocUtf8String("r");
+
+        const file = popen(libcCommand, libcCommandMode);
+        if (file.isNull()) {
+            return null;
+        }
+
+        const bufferSize: number = 1024;
+        const buffer = Memory.alloc(bufferSize);
+        let output = "";
+        while (!(fgets(buffer, bufferSize, file)).isNull()) {
+            output += buffer.readUtf8String();
+        }
+        pclose(file);
+
+        return output;
+
+    }
+
+    return null;
+
+}
+
+
+export function runSystemCommandAsString(args: string[]): string | null {
+    return runCommandAsString(args.join(" "));
+}
+

--- a/src/agent/lib/debug/system.ts
+++ b/src/agent/lib/debug/system.ts
@@ -24,16 +24,21 @@ export function runSystemCommand(args: string[]): string | null {
     return runSystem(args.join(" "));
 }
 
-
 export function runCommandAsString(command: string): string | null {
-
     const popenSymbol = getGlobalExportByName("popen");
     const fgetsSymbol = getGlobalExportByName("fgets");
     const pcloseSymbol = getGlobalExportByName("pclose");
 
     if (popenSymbol !== null && fgetsSymbol !== null && pcloseSymbol !== null) {
-        const popen = new NativeFunction(popenSymbol, "pointer", ["pointer", "pointer"]);
-        const fgets = new NativeFunction(fgetsSymbol, "pointer", ["pointer", "int", "pointer"]);
+        const popen = new NativeFunction(popenSymbol, "pointer", [
+            "pointer",
+            "pointer",
+        ]);
+        const fgets = new NativeFunction(fgetsSymbol, "pointer", [
+            "pointer",
+            "int",
+            "pointer",
+        ]);
         const pclose = new NativeFunction(pcloseSymbol, "int", ["pointer"]);
 
         const libcCommand = Memory.allocUtf8String(command);
@@ -53,15 +58,11 @@ export function runCommandAsString(command: string): string | null {
         pclose(file);
 
         return output;
-
     }
 
     return null;
-
 }
-
 
 export function runSystemCommandAsString(args: string[]): string | null {
     return runCommandAsString(args.join(" "));
 }
-


### PR DESCRIPTION
This introduces a new utility function that runs system command and displays the output.

To run a system command, you can use the following syntax: `:!!<cmd>`

```sh
[0x00000000]> :!!ls -lah
```

![Screenshot from 2025-06-19 20-39-27](https://github.com/user-attachments/assets/b6404a22-307d-4b79-8dd8-f61fc89c799d)

Issue: #563 