### PR TITLE
Fix remote fs directory listing

### DIFF
--- a/dist/docker/dirent.c
+++ b/dist/docker/dirent.c
@@ -1,0 +1,55 @@
+#define _DIRENT_HAVE_D_RECLEN 1
+#define _DIRENT_HAVE_D_TYPE 1
+// #define _DIRENT_HAVE_D_OFF 1
+#define _DIRENT_HAVE_D_INO 1
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <dirent.h>
+#include <errno.h>
+
+#define offsetof(type, field) (int)((size_t) &((type *)0)->field)
+#define A(a,b) printf ("%d\t%s\n", offsetof (struct dirent, a), b)
+
+int main() {
+	DIR *dir;
+	struct dirent *entry;
+	struct dirent entry_buffer;
+	int result;
+
+	dir = opendir("/bin");
+	if (!dir) {
+		perror("opendir");
+		return EXIT_FAILURE;
+	}
+
+	while ((result = readdir_r(dir, &entry_buffer, &entry)) == 0 && entry != NULL) {
+		printf("Directory entry: %s\n", entry->d_name);
+
+		// Print the offsets of struct dirent fields
+		A(d_name, "d_name");
+#ifdef _DIRENT_HAVE_D_RECLEN
+		A(d_reclen, "d_reclen");
+#endif
+#ifdef _DIRENT_HAVE_D_TYPE
+		A(d_type, "d_type");
+#endif
+#ifdef _DIRENT_HAVE_D_OFF
+		A(d_off, "d_off");
+#endif
+#ifdef _DIRENT_HAVE_D_INO
+		A(d_ino, "d_ino");
+#endif
+		break; // Remove this line if you want to continue reading all entries
+	}
+
+	if (result != 0) {
+		perror("readdir_r");
+		closedir(dir);
+		return EXIT_FAILURE;
+	}
+
+	closedir(dir);
+	return EXIT_SUCCESS;
+}
+

--- a/src/agent/lib/darwin/index.ts
+++ b/src/agent/lib/darwin/index.ts
@@ -1,6 +1,7 @@
 import {
     autoType,
     getGlobalExportByName,
+    findGlobalExportByName,
     padPointer,
     trunc4k,
 } from "../utils.js";
@@ -142,8 +143,8 @@ export function callObjcMethod(args: string[]): string {
     return "";
 }
 export function hasMainLoop(): boolean {
-    const getMainPtr = getGlobalExportByName("CFRunLoopGetMain");
-    const copyCurrentModePtr = getGlobalExportByName(
+    const getMainPtr = findGlobalExportByName("CFRunLoopGetMain");
+    const copyCurrentModePtr = findGlobalExportByName(
         "CFRunLoopCopyCurrentMode",
     );
     if (getMainPtr === null || copyCurrentModePtr === null) {

--- a/src/agent/lib/fs.ts
+++ b/src/agent/lib/fs.ts
@@ -515,8 +515,7 @@ class DirEnt {
     }
 }
 
-function readDirentField(entry: NativePointer, name: string): number | string {
-    const [offset, type] = direntSpec[name];
+function readMemoryField(entry: NativePointer, offset: number, type: string): number | string {
     let value: any = null;
     switch (type) {
         case "Utf8String":
@@ -539,39 +538,20 @@ function readDirentField(entry: NativePointer, name: string): number | string {
     return value;
 }
 
+
+function readDirentField(entry: NativePointer, name: string): number | string {
+    const [offset, type] = direntSpec[name];
+    return readMemoryField(entry, offset, type);
+}
+
 function readStatField(entry: NativePointer, name: string): number {
     const [offset, type] = statSpec[name];
-    let value: any = null;
-    switch (type) {
-        case "S32":
-            value = entry.add(offset).readS32();
-            break;
-        case "S64":
-            value = entry.add(offset).readS64();
-            break;
-        default:
-            throw new Error("Unknown type: " + type);
-    }
-    if (value instanceof Int64 || value instanceof UInt64) {
-        return value.valueOf();
-    }
-    return value;
+    return readMemoryField(entry, offset, type) as number;
 }
 
 function readStatxField(entry: NativePointer, name: string): number {
     const [offset, type] = statxSpec[name];
-    let value: any = null;
-    switch (type) {
-        case "S64":
-            value = entry.add(offset).readS64();
-            break;
-        default:
-            throw new Error("Unknown type: " + type);
-    }
-    if (value instanceof Int64 || value instanceof UInt64) {
-        return value.valueOf();
-    }
-    return value;
+    return readMemoryField(entry, offset, type) as number;
 }
 
 export function resolveExports(names: string[]): Record<string, NativePointer> {

--- a/src/agent/lib/fs.ts
+++ b/src/agent/lib/fs.ts
@@ -57,7 +57,8 @@ const statxSpecs = {
     },
 };
 const STATX_SIZE = 0x200;
-let has64BitInode: boolean | null = null;
+let has64BitInode: boolean = false;
+let has64BitInodeChecked: boolean = false;
 const direntSpec = (direntSpecs as any)[`${platform}-${pointerSize * 8}`];
 const statSpec = (statSpecs as any)[`${platform}-${pointerSize * 8}`] || null;
 const statxSpec = (statxSpecs as any)[`${platform}-${pointerSize * 8}`] || null;
@@ -578,13 +579,14 @@ function readStatxField(entry: NativePointer, name: string): number | undefined 
 }
 
 export function direntHas64BitInode(dirEntPtr: NativePointer): boolean {
-    if (has64BitInode !== null) {
+    if (has64BitInodeChecked) {
         return has64BitInode;
     }
     const recLen = dirEntPtr.add(4).readU16();
     const nameLen = dirEntPtr.add(7).readU8();
     const compLen = (8 + nameLen + 3) & ~3;
     has64BitInode = compLen !== recLen;
+    has64BitInodeChecked = true;
     return has64BitInode;
 }
 

--- a/src/agent/lib/utils.ts
+++ b/src/agent/lib/utils.ts
@@ -365,7 +365,11 @@ export function Hexdump(lenstr: number): string {
     }
 }
 
-export function getGlobalExportByName(name: string): any {
+export function getGlobalExportByName(name: string): NativePointer {
+    return Module.getGlobalExportByName(name);
+}
+
+export function findGlobalExportByName(name: string): NativePointer | null {
     return Module.findGlobalExportByName(name);
 }
 


### PR DESCRIPTION
It was crashing with `not a function` error when accessing the remote FS using, for example, the `:md` command. 

This MR includes the fix in the `readDirentField` function, which had some errors parsing the offsets of the DirEnt struct.

Moreover, it includes the  following changes:
- Add types to fs.ts
- Some minimal refactoring.
- Deprecates darwin-32 support.
- Add dirent.c to list the hardcoded offsets per platform.