### PR TITLE
Fix build with agent pre-downloaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,7 @@ LDFLAGS+=-Wl,--end-group
 endif
 
 all: ext/frida
-	rm -f src/_agent*
-ifeq ($(frida_version_major),16)
+ifneq ($(R2FRIDA_HOST_COMPILER),1)
 	$(MAKE) src/r2frida-compile
 endif
 	$(MAKE) io_frida.$(SO_EXT)
@@ -253,15 +252,17 @@ src/_agent.js:
 	mv src/_agent.js.host src/_agent.js
 	test -s src/_agent.js || rm -f src/_agent.js
 else
-src/_agent.js: src/r2frida-compile
 ifeq ($(R2FRIDA_PRECOMPILED_AGENT),1)
+src/_agent.js:
 	$(DLCMD) src/_agent.js $(R2FRIDA_PRECOMPILED_AGENT_URL)
 else
 ifeq ($(USE_FRIDA_TOOLS),1)
+src/_agent.js:
 	frida-pm install
 	frida-compile -o src/_agent.js -Sc src/agent/index.ts
 	rax2 -qC < src/_agent.js > src/_agent.h
 else
+src/_agent.js: src/r2frida-compile
 	R2PM_OFFLINE=1 r2pm -r src/r2frida-compile -i || src/r2frida-compile -i
 	R2PM_OFFLINE=1 r2pm -r src/r2frida-compile -H src/_agent.h -o src/_agent.js -Sc src/agent/index.ts || \
 		src/r2frida-compile -H src/_agent.h -o src/_agent.js -Sc src/agent/index.ts


### PR DESCRIPTION
When predownloading the agent into `src/_agent.js` the current approach redownloads every time `src/r2frida-compile` gets modified.

This proposal is to avoid this behavior.

Tested sandbox (no network) build using flatpak.
<details>
<summary>Example flatpak module code</summary>

```yaml
modules:
  - name: r2frida
    buildsystem: autotools
    build-options:
      cflags: -O3
    config-opts:
      - --with-precompiled-agent
      - --with-checks-level=0
    sources:
      - type: git
        url: https://github.com/prodrigestivill/radare-r2frida.git
        tag: fix/no-network
        commit: 9f87011a5ab31b5dbc4f7d7f072560df29d07b8a
      - type: file
        url: https://github.com/nowsecure/r2frida/releases/download/6.0.2/_agent.js
        sha256: 998234270298102dc5d3a4ef07a1888c36616d5a3bf5bfc598b9c563e34d4274
        dest: src
        dest-filename: _agent.js
        x-checker-data:
          type: json
          url: https://api.github.com/repos/nowsecure/r2frida/releases/latest
          timestamp-query: .published_at
          version-query: .tag_name
          url-query: |-
            .assets[] | select(.name=="_agent.js") | .browser_download_url
      - type: file
        url: https://github.com/frida/frida/releases/download/17.2.15/frida-core-devkit-17.2.15-linux-x86_64.tar.xz
        sha256: 068cec1b56debb77cfdfe0c4e916b98382b2a03f7b4f4cf66f2ed3e3da0f776f
        only-arches: [x86_64]
        x-checker-data:
          type: json
          url: https://api.github.com/repos/nowsecure/r2frida/releases/latest
          version-query: .body | capture("Frida +(?<frida_version>[0-9.]+)") | .frida_version
          url-data-url: >-
            "https://api.github.com/repos/frida/frida/releases/tags/\($version)"
          url-query: |-
            .assets[] | select(.name=="frida-core-devkit-" + $version + "-linux-x86_64.tar.xz") | .browser_download_url
      - type: file
        url: https://github.com/frida/frida/releases/download/17.2.15/frida-core-devkit-17.2.15-linux-arm64.tar.xz
        sha256: aad9bee0a8567d0e87fbb528cfd6303a7ae0cd64a7718cd3b0fb6ad5f06c0828
        only-arches: [aarch64]
        x-checker-data:
          type: json
          url: https://api.github.com/repos/nowsecure/r2frida/releases/latest
          version-query: .body | capture("Frida +(?<frida_version>[0-9.]+)") | .frida_version
          url-data-url: >-
            "https://api.github.com/repos/frida/frida/releases/tags/\($version)"
          url-query: |-
            .assets[] | select(.name=="frida-core-devkit-" + $version + "-linux-arm64.tar.xz") | .browser_download_url
      - type: shell # decompress frida-sdk keeping its own version
        commands:
          - FRIDA_DEST=$(echo frida-core-devkit-*.tar.xz | sed -r 's,^.*-([0-9\.]+)-.*$,ext/frida-linux-\1,');
            mkdir -vp "${FRIDA_DEST}" && tar -vxJf frida-core-devkit-*.tar.xz -C "${FRIDA_DEST}"
          - rm -vf frida-core-devkit-*.tar.xz
```
</details>