### PR TITLE
fix segfault in strdup(NULL) at src/io_frida.c:886

### DIFF
--- a/src/io_frida.c
+++ b/src/io_frida.c
@@ -881,7 +881,7 @@ static char *__system_continuation(RIO *io, RIODesc *fd, const char *command) {
 		return NULL;
 	}
 	const char *value = json_object_get_string_member (result, "value");
-	char *sys_result = strdup (value);
+	char *sys_result = value? strdup (value): NULL;
 	json_object_unref (result);
 
 	return sys_result;


### PR DESCRIPTION
Fix a segmentation fault when loading a JavaScript.

Root cause: strdup(NULL) at src/io_frida.c:886. The "value" member of the agent's evaluate reply exists but is JSON null (the loaded script returns no value), and json_object_get_string_member() returns NULL.

Fix: char *sys_result = value? strdup (value): NULL; — one-line NULL guard, no behavioral change for the success path.